### PR TITLE
update services to use new service ordering

### DIFF
--- a/d/debian-console.yml
+++ b/d/debian-console.yml
@@ -1,10 +1,9 @@
 console:
   image: rancher/os-debianconsole:v0.4.0-dev
   privileged: true
-  links:
-  - cloud-init
   labels:
-  - io.rancher.os.scope=system
+    io.rancher.os.scope: system
+    io.rancher.os.after: cloud-init
   volumes_from:
   - all-volumes
   restart: always

--- a/u/ubuntu-console.yml
+++ b/u/ubuntu-console.yml
@@ -1,10 +1,9 @@
 console:
   image: rancher/os-ubuntuconsole:v0.4.0-dev
   privileged: true
-  links:
-  - cloud-init
   labels:
-  - io.rancher.os.scope=system
+    io.rancher.os.scope: system
+    io.rancher.os.after: cloud-init
   volumes_from:
   - all-volumes
   restart: always


### PR DESCRIPTION
update services to use new service ordering

use `io.rancher.os.after: dep1,dep2` label instead of links