### PR TITLE
Fix missing FORCE environment var

### DIFF
--- a/r/resize-fs.yml
+++ b/r/resize-fs.yml
@@ -2,6 +2,7 @@ resizefs:
   image: rancher/os-resizefs:v0.4.5
   environment:
   - RESIZE_DEV
+  - FORCE
   privileged: true
   labels:
     io.rancher.os.detach: false


### PR DESCRIPTION
The FORCE environment var was added in os-images#47 but was missing in the service definition