### PR TITLE
Replace wait-for-network with network

### DIFF
--- a/c/centos-console.yml
+++ b/c/centos-console.yml
@@ -3,7 +3,7 @@ console:
   privileged: true
   labels:
     io.rancher.os.scope: system
-    io.rancher.os.after: wait-for-network
+    io.rancher.os.after: network
     io.docker.compose.rebuild: false
   volumes_from:
   - all-volumes

--- a/d/debian-console.yml
+++ b/d/debian-console.yml
@@ -3,7 +3,7 @@ console:
   privileged: true
   labels:
     io.rancher.os.scope: system
-    io.rancher.os.after: wait-for-network
+    io.rancher.os.after: network
     io.docker.compose.rebuild: false
   volumes_from:
   - all-volumes

--- a/f/fedora-console.yml
+++ b/f/fedora-console.yml
@@ -3,7 +3,7 @@ console:
   privileged: true
   labels:
     io.rancher.os.scope: system
-    io.rancher.os.after: wait-for-network
+    io.rancher.os.after: network
     io.docker.compose.rebuild: false
   volumes_from:
   - all-volumes

--- a/u/ubuntu-console.yml
+++ b/u/ubuntu-console.yml
@@ -3,7 +3,7 @@ console:
   privileged: true
   labels:
     io.rancher.os.scope: system
-    io.rancher.os.after: wait-for-network
+    io.rancher.os.after: network
     io.docker.compose.rebuild: false
   volumes_from:
   - all-volumes


### PR DESCRIPTION
`wait-for-network` was removed as of rancher/os#958