### PR TITLE
Allow ECS agent version to be customized

### DIFF
--- a/a/amazon-ecs-agent.yml
+++ b/a/amazon-ecs-agent.yml
@@ -1,5 +1,5 @@
 ecs-agent:
-  image: amazon/amazon-ecs-agent
+  image: amazon/amazon-ecs-agent${ECS_AGENT_VERSION}
   labels:
     io.rancher.os.scope: system
     io.rancher.os.after: docker


### PR DESCRIPTION
This allows the ECS agent version to be customized using environment variable interpolation (default is still `latest`). For example, the version can be set to `v1.7.1` with the following in a cloud config:

```
rancher:
  environment:
  - ECS_AGENT_VERSION=:v1.7.1
```

The colon in the value is unfortunate, but it's necessary since there isn't currently a way to specify default values for environment variables in Compose files.

Ping @JasonSwindle

rancher/os#777