### PR TITLE
open-vm-tools service

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -2,6 +2,7 @@ services:
 - amazon-ecs-agent
 - kernel-headers
 - kernel-headers-system-docker
+- open-vm-tools
 consoles:
 - centos
 - debian

--- a/o/open-vm-tools.yml
+++ b/o/open-vm-tools.yml
@@ -1,0 +1,11 @@
+open-vm-tools:
+  image: rancher/os-openvmtools:v0.5.0
+  command: /usr/bin/vmtoolsd
+  privileged: true
+  labels:
+    io.rancher.os.scope: system
+  restart: always
+  pid: host
+  ipc: host
+  net: host
+  uts: host


### PR DESCRIPTION
Depends on rancher/os-images#89

Adds a system service for `open-vm-tools`. Based on Alpine since the package is up to date and it saves us from having to build it ourselves.

Guest info functionality seems to be working in Fusion and Docker Machine with the Fusion driver. Soft power operations still need some wiring to work properly.

rancher/os#219