### PR TITLE
xfce should only be available as console

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -4,7 +4,6 @@ services:
 - kernel-headers
 - kernel-headers-system-docker
 - open-vm-tools
-- xfce
 consoles:
 - centos
 - debian


### PR DESCRIPTION
xfce makes more sense as a console than it does as a service. Having it as both will probably cause some confusion.