### PR TITLE
Add ros to kernel header services

### DIFF
--- a/k/kernel-headers-system-docker.yml
+++ b/k/kernel-headers-system-docker.yml
@@ -9,3 +9,4 @@ kernel-headers-system-docker:
   volumes:
   - /usr/src:/usr/src
   - /lib/modules:/lib/modules
+  - /usr/bin/ros:/usr/bin/ros

--- a/k/kernel-headers.yml
+++ b/k/kernel-headers.yml
@@ -8,3 +8,4 @@ kernel-headers:
   volumes:
   - /usr/src:/usr/src
   - /lib/modules:/lib/modules
+  - /usr/bin/ros:/usr/bin/ros


### PR DESCRIPTION
Needed for `ros entrypoint`.