### PR TITLE
Remove unnecessary fields from kernel extras/headers

### DIFF
--- a/k/kernel-extras.yml
+++ b/k/kernel-extras.yml
@@ -3,9 +3,6 @@ kernel-extras:
   labels:
     io.rancher.os.detach: false
     io.rancher.os.after: network
-  net: host
-  environment:
-  - KERNEL_EXTRAS_URL
   volumes:
   - /usr/src:/usr/src
   - /lib/modules:/lib/modules

--- a/k/kernel-headers-system-docker.yml
+++ b/k/kernel-headers-system-docker.yml
@@ -4,8 +4,6 @@ kernel-headers-system-docker:
     io.rancher.os.detach: false
     io.rancher.os.after: network
     io.rancher.os.scope: system
-  environment:
-  - KERNEL_HEADERS_URL
   volumes:
   - /usr/src:/usr/src
   - /lib/modules:/lib/modules

--- a/k/kernel-headers.yml
+++ b/k/kernel-headers.yml
@@ -3,8 +3,6 @@ kernel-headers:
   labels:
     io.rancher.os.detach: false
     io.rancher.os.after: network
-  environment:
-  - KERNEL_HEADERS_URL
   volumes:
   - /usr/src:/usr/src
   - /lib/modules:/lib/modules


### PR DESCRIPTION
Since the assets for these are now embedded in the images themselves, these attributes aren't needed anymore.