### PR TITLE
Remove getty symlink

### DIFF
--- a/images/10-alpineconsole/Dockerfile
+++ b/images/10-alpineconsole/Dockerfile
@@ -3,7 +3,6 @@ FROM rancher/os-alpineconsole-base
 RUN apk --no-cache add bash openssh iptables rsync sudo vim less curl ca-certificates htop kmod iproute2 util-linux
 # missing packages at 2016-Nov: locales psmisc
 RUN rm -rf /etc/ssh/*key*
-#RUN ln -s /sbin/getty /sbin/agetty
 #RUN locale-gen en_US.UTF-8
 RUN addgroup -g 1100 rancher && \
     addgroup -g 1101 docker && \

--- a/images/10-centosconsole/Dockerfile
+++ b/images/10-centosconsole/Dockerfile
@@ -1,8 +1,7 @@
 FROM rancher/os-centosconsole-base
 # FROM amd64=centos:7 arm64=skip arm=skip
 RUN yum install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng \
-    && rm -rf /etc/ssh/*key* \
-    && ln -s /sbin/agetty /sbin/getty
+    && rm -rf /etc/ssh/*key*
 RUN localedef -c -f UTF-8 -i en_US en_US.UTF-8 \
     && groupadd --gid 1100 rancher \
     && groupadd --gid 1101 docker \

--- a/images/10-fedoraconsole/Dockerfile
+++ b/images/10-fedoraconsole/Dockerfile
@@ -1,8 +1,7 @@
 FROM rancher/os-fedoraconsole-base
 # FROM amd64=fedora:24 arm64=skip arm=skip
 RUN dnf install -y iptables openssh-server rsync sudo vim less ca-certificates psmisc htop procps-ng \
-    && rm -rf /etc/ssh/*key* \
-    && ln -s /sbin/agetty /sbin/getty
+    && rm -rf /etc/ssh/*key*
 RUN groupadd --gid 1100 rancher \
     && groupadd --gid 1101 docker \
     && useradd -u 1100 -g rancher -G docker,wheel -m -s /bin/bash rancher \


### PR DESCRIPTION
We're actually using `agetty` now, so this symlink is no longer necessary. Looking back, I think there was a better method than symlinking this anyways.