### PR TITLE
WIP: Zfs service

### DIFF
--- a/images/20-zfs/Dockerfile
+++ b/images/20-zfs/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+# FROM arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
+
+
+RUN apt-get update \
+    && apt-get install -yq build-essential autoconf libtool gawk alien fakeroot \
+	zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libdevmapper-dev \
+	parted lsscsi ksh curl git
+
+WORKDIR /dist
+COPY build.sh /dist/
+
+CMD ["/dist/build.sh"]
+

--- a/images/20-zfs/Dockerfile
+++ b/images/20-zfs/Dockerfile
@@ -5,10 +5,13 @@ FROM ubuntu:16.04
 RUN apt-get update \
     && apt-get install -yq build-essential autoconf libtool gawk alien fakeroot \
 	zlib1g-dev uuid-dev libattr1-dev libblkid-dev libselinux-dev libudev-dev libdevmapper-dev \
+	module-init-tools \
 	parted lsscsi ksh curl git
 
 WORKDIR /dist
 COPY build.sh /dist/
+COPY wonka.sh /dist/
+COPY Dockerfile.zfs-tools /dist/
 
 CMD ["/dist/build.sh"]
 

--- a/images/20-zfs/Dockerfile
+++ b/images/20-zfs/Dockerfile
@@ -15,3 +15,4 @@ COPY Dockerfile.zfs-tools /dist/
 
 CMD ["/dist/build.sh"]
 
+ENTRYPOINT ["/usr/bin/ros", "entrypoint"]

--- a/images/20-zfs/Dockerfile.zfs-tools
+++ b/images/20-zfs/Dockerfile.zfs-tools
@@ -1,0 +1,9 @@
+FROM ubuntu:16.04
+# FROM arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
+
+ADD bin/* /usr/local/bin/
+ADD sbin/* /usr/local/sbin/
+ADD lib/* /usr/local/lib/
+ADD libexec/* /usr/local/libexec/
+
+RUN ldconfig

--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -58,6 +58,24 @@ else
    git clone https://github.com/zfsonlinux/zfs
 fi
 
+if [ "$KERNEL_VERSION" = "4.9.2-rancher" ]; then
+    echo "Detected $KERNEL_VERSION, using zfs master for now"
+    cd spl
+    git checkout master
+    cd ..
+    cd zfs
+    git checkout master
+    cd ..
+else
+    cd spl
+    git checkout spl-0.6.5-release
+    cd ..
+    cd zfs
+    git checkout zfs-0.6.5-release
+    cd ..
+fi
+
+
 # get headers for the kernel we're building for
 #ENV LINUX 4.9.2-rancher
 #RUN curl -sL https://github.com/rancher/os-kernel/releases/download/v${LINUX}/build-linux-${LINUX}-x86.tar.gz > build-linux-${LINUX}-x86.tar.gz

--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -12,6 +12,9 @@ if [ -e $STAMP ]; then
     exit 0
 fi
 
+#TODO: test that the headers are there
+#TODO: or, if we continue to be able to use the docker daemon, can we use ros to enable and up it?
+
 
 # get the zfs source as per https://github.com/zfsonlinux/zfs/wiki/Building-ZFS
 #ENV VERSION 0.6.5.8
@@ -68,6 +71,22 @@ make install
 cd /dist/zfs
 make install
 
+depmod
+
+cp /dist/Dockerfile.zfs-tools /dist/arch/Dockerfile
+system-docker build -t zfs-tools arch/
+
+# how do I export the bins to the console?
+# in the future, it'd be nice to have some share /usr/local/bin, but that might interfere with other things.
+# we do seem to have /opt mapped
+# cp /dist/wonka.sh /usr/local/bin/zpool
+
+for i in $(ls arch/bin); do 
+	system-docker cp wonka.sh console:/usr/bin/$i
+done
+for i in $(ls arch/sbin); do 
+	system-docker cp wonka.sh console:/usr/sbin/$i
+done
 
 touch $STAMP
 echo ZFS for ${KERNEL_VERSION} installed. Delete $STAMP to reinstall

--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -1,6 +1,20 @@
 #!/bin/sh
 set -ex
 
+setupconsolecommands()
+{
+    # how do I export the commands to the console?
+    # in the future, it'd be nice to have some share /usr/local/bin, but that might interfere with other things.
+    # we do seem to have /opt mapped
+
+    for i in $(ls arch/bin); do
+       system-docker cp wonka.sh console:/usr/bin/$i
+    done
+    for i in $(ls arch/sbin); do
+       system-docker cp wonka.sh console:/usr/sbin/$i
+    done
+}
+
 KERNEL_VERSION=$(uname -r)
 echo "zfs for ${KERNEL_VERSION}"
 
@@ -8,37 +22,40 @@ DIR=/lib/modules/${KERNEL_VERSION}/build
 STAMP=/lib/modules/${KERNEL_VERSION}/.zfs-done
 
 if [ -e $STAMP ]; then
+    setupconsolecommands
     echo ZFS for ${KERNEL_VERSION} already installed. Delete $STAMP to reinstall
     exit 0
 fi
 
 #TODO: test that the headers are there
 #TODO: or, if we continue to be able to use the docker daemon, can we use ros to enable and up it?
+ros service enable kernel-headers-system-docker
+ros service up kernel-headers-system-docker
 
 
 # get the zfs source as per https://github.com/zfsonlinux/zfs/wiki/Building-ZFS
 #ENV VERSION 0.6.5.8
 # need 0.7.0 for linux 4.9
 #ENV VERSION 0.7.0-rc2
-#RUN curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/spl-${VERSION}.tar.gz > spl-${VERSION}.tar.gz \ 
+#RUN curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/spl-${VERSION}.tar.gz > spl-${VERSION}.tar.gz \
 #curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/zfs-${VERSION}.tar.gz > zfs-${VERSION}.tar.gz
 #tar zxvf spl-${VERSION}.tar.gz
-#tar zxvf zfs-${VERSION}.tar.gz 
+#tar zxvf zfs-${VERSION}.tar.gz
 #ENV VERSION 0.7.0
 # 0.7.0-rc2 not enough for 4.9
 if [ -d "spl" ]; then
-	cd spl
-	git pull
-	cd ..
+   cd spl
+   git pull
+   cd ..
 else
-	git clone https://github.com/zfsonlinux/spl
+   git clone https://github.com/zfsonlinux/spl
 fi
 if [ -d "zfs" ]; then
-	cd zfs
-	git pull
-	cd ..
+   cd zfs
+   git pull
+   cd ..
 else
-	git clone https://github.com/zfsonlinux/zfs
+   git clone https://github.com/zfsonlinux/zfs
 fi
 
 # get headers for the kernel we're building for
@@ -70,23 +87,14 @@ cd /dist/spl
 make install
 cd /dist/zfs
 make install
+cd /dist
 
 depmod
 
 cp /dist/Dockerfile.zfs-tools /dist/arch/Dockerfile
 system-docker build -t zfs-tools arch/
 
-# how do I export the bins to the console?
-# in the future, it'd be nice to have some share /usr/local/bin, but that might interfere with other things.
-# we do seem to have /opt mapped
-# cp /dist/wonka.sh /usr/local/bin/zpool
-
-for i in $(ls arch/bin); do 
-	system-docker cp wonka.sh console:/usr/bin/$i
-done
-for i in $(ls arch/sbin); do 
-	system-docker cp wonka.sh console:/usr/sbin/$i
-done
+setupconsolecommands
 
 touch $STAMP
 echo ZFS for ${KERNEL_VERSION} installed. Delete $STAMP to reinstall

--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+set -ex
+
+KERNEL_VERSION=$(uname -r)
+echo "zfs for ${KERNEL_VERSION}"
+
+DIR=/lib/modules/${KERNEL_VERSION}/build
+STAMP=/lib/modules/${KERNEL_VERSION}/.zfs-done
+
+if [ -e $STAMP ]; then
+    echo ZFS for ${KERNEL_VERSION} already installed. Delete $STAMP to reinstall
+    exit 0
+fi
+
+
+# get the zfs source as per https://github.com/zfsonlinux/zfs/wiki/Building-ZFS
+#ENV VERSION 0.6.5.8
+# need 0.7.0 for linux 4.9
+#ENV VERSION 0.7.0-rc2
+#RUN curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/spl-${VERSION}.tar.gz > spl-${VERSION}.tar.gz \ 
+#curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/zfs-${VERSION}.tar.gz > zfs-${VERSION}.tar.gz
+#tar zxvf spl-${VERSION}.tar.gz
+#tar zxvf zfs-${VERSION}.tar.gz 
+#ENV VERSION 0.7.0
+# 0.7.0-rc2 not enough for 4.9
+if [ -d "spl" ]; then
+	cd spl
+	git pull
+	cd ..
+else
+	git clone https://github.com/zfsonlinux/spl
+fi
+if [ -d "zfs" ]; then
+	cd zfs
+	git pull
+	cd ..
+else
+	git clone https://github.com/zfsonlinux/zfs
+fi
+
+# get headers for the kernel we're building for
+#ENV LINUX 4.9.2-rancher
+#RUN curl -sL https://github.com/rancher/os-kernel/releases/download/v${LINUX}/build-linux-${LINUX}-x86.tar.gz > build-linux-${LINUX}-x86.tar.gz
+#
+#RUN mkdir ${LINUX}
+#RUN cd ${LINUX}
+#tar zxvf ../build-linux-${LINUX}-x86.tar.gz
+
+
+#   --prefix=/dist
+cd /dist/spl
+sh ./autogen.sh
+./configure \
+          --exec-prefix=/dist/arch \
+          --with-linux=${DIR}
+make -s -j$(nproc)
+
+cd /dist/zfs
+sh ./autogen.sh
+./configure \
+          --exec-prefix=/dist/arch \
+          --with-linux=${DIR}
+make -s -j$(nproc)
+
+# last layer - we could use stratos :)
+cd /dist/spl
+make install
+cd /dist/zfs
+make install
+
+
+touch $STAMP
+echo ZFS for ${KERNEL_VERSION} installed. Delete $STAMP to reinstall

--- a/images/20-zfs/dev.sh
+++ b/images/20-zfs/dev.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+docker build -t zfs .
+docker run --rm -it \
+	--volume /usr/src:/usr/src \
+	--volume /lib/modules:/lib/modules \
+        --volume $(pwd):/dist \
+	zfs bash

--- a/images/20-zfs/dev.sh
+++ b/images/20-zfs/dev.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-docker build -t zfs .
-docker run --rm -it \
-	--volume /usr/src:/usr/src \
-	--volume /lib/modules:/lib/modules \
-        --volume $(pwd):/dist \
-	zfs bash

--- a/images/20-zfs/wonka.sh
+++ b/images/20-zfs/wonka.sh
@@ -4,4 +4,5 @@ exec system-docker run --rm -it --privileged \
                 --pid host \
                 --net host \
                 --ipc host \
+		-v /mnt:/mnt:shared \
 		zfs-tools $(basename $0) $@

--- a/images/20-zfs/wonka.sh
+++ b/images/20-zfs/wonka.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec system-docker run --rm -it --privileged zfs-tools $(basename $0) $@

--- a/images/20-zfs/wonka.sh
+++ b/images/20-zfs/wonka.sh
@@ -1,3 +1,7 @@
 #!/bin/sh
 
-exec system-docker run --rm -it --privileged zfs-tools $(basename $0) $@
+exec system-docker run --rm -it --privileged \
+                --pid host \
+                --net host \
+                --ipc host \
+		zfs-tools $(basename $0) $@

--- a/index.yml
+++ b/index.yml
@@ -4,6 +4,7 @@ services:
 - kernel-headers
 - kernel-headers-system-docker
 - open-vm-tools
+- zfs
 consoles:
 - alpine
 - centos

--- a/z/zfs.yml
+++ b/z/zfs.yml
@@ -1,9 +1,19 @@
-kernel-headers:
-  image: rancher/zfs:${SUFFIX}
+zfs:
+  image: zombie/zfs
+  command: ./build.sh
+  privileged: true
   labels:
-    io.rancher.os.detach: false
+    io.rancher.os.scope: system
+#    io.rancher.os.detach: false
     io.rancher.os.after: network
   volumes:
   - /usr/src:/usr/src
-  - /lib/modules:/lib/modules
-  - /usr/bin/ros:/usr/bin/ros
+#  - /lib/modules:/lib/modules
+#  - /usr/bin/ros:/usr/bin/ros
+  volumes_from:
+  - all-volumes
+  restart: always
+  pid: host
+  ipc: host
+  net: host
+  uts: host

--- a/z/zfs.yml
+++ b/z/zfs.yml
@@ -5,7 +5,7 @@ zfs:
   labels:
     io.rancher.os.scope: system
 #    io.rancher.os.detach: false
-    io.rancher.os.after: network
+    io.rancher.os.after: console
   volumes:
   - /usr/src:/usr/src
 #  - /lib/modules:/lib/modules

--- a/z/zfs.yml
+++ b/z/zfs.yml
@@ -1,0 +1,9 @@
+kernel-headers:
+  image: rancher/zfs:${SUFFIX}
+  labels:
+    io.rancher.os.detach: false
+    io.rancher.os.after: network
+  volumes:
+  - /usr/src:/usr/src
+  - /lib/modules:/lib/modules
+  - /usr/bin/ros:/usr/bin/ros


### PR DESCRIPTION
there will be a docs PR in the rancher/os repo to go with this

So far, i've been working with 0.7.1, so there's more work to go

basically

```
ros service enable zfs
ros service up zfs
```

will git clone zfsonlinux, and then build it for the currently running kernel
it'll then build a new zfs-tools image, and then system-docker cp wonka's for each file in bin&sbin into the console.

> *NOTE:* atm, I'm using the dev HEAD of the git repo, because that's what builds on the 4.9 kernel - that will change as time goes on.

TODO (some in a later PR):
- [x] as we have access to ros and system-docker, enable and up the kernel-headers in the build script - as an implicit dep.
- [x] re-do the wonka's every boot for non-persistent console
- [x] test a zpool
- [ ] test user docker running with a zpool
- [x] make a cloud-init that uses zfs
- [x] test with 0.8.0

LATER

- [ ] prebuild install tarballs and images for specific releases so users of our official releases don't need to build locally (I don't have time yet)