### PR TITLE
Fix zfs

### DIFF
--- a/images/20-zfs/Dockerfile
+++ b/images/20-zfs/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
 	parted lsscsi ksh curl git
 
 WORKDIR /dist
+COPY entry.sh /dist/
 COPY build.sh /dist/
 COPY wonka.sh /dist/
 COPY Dockerfile.zfs-tools /dist/

--- a/images/20-zfs/Dockerfile.zfs-tools
+++ b/images/20-zfs/Dockerfile.zfs-tools
@@ -1,9 +1,13 @@
 FROM ubuntu:16.04
 # FROM arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
 
-ADD bin/* /usr/local/bin/
-ADD sbin/* /usr/local/sbin/
-ADD lib/* /usr/local/lib/
-ADD libexec/* /usr/local/libexec/
+ADD entry.sh /usr/local/bin/
+ADD sbin/* /sbin/
+ADD usr/local/sbin/* /usr/local/sbin/
+ADD usr/local/bin/* /usr/local/bin/
+ADD usr/local/lib/* /usr/local/lib/
+ADD usr/local/libexec/* /usr/local/libexec/
 
 RUN ldconfig
+
+ENTRYPOINT ["/usr/local/bin/entry.sh"]

--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -7,11 +7,14 @@ setupconsolecommands()
     # in the future, it'd be nice to have some share /usr/local/bin, but that might interfere with other things.
     # we do seem to have /opt mapped
 
-    for i in $(ls arch/bin); do
+    for i in $(ls arch/usr/local/bin); do
        system-docker cp wonka.sh console:/usr/bin/$i
     done
-    for i in $(ls arch/sbin); do
+    for i in $(ls arch/usr/local/sbin); do
        system-docker cp wonka.sh console:/usr/sbin/$i
+    done
+    for i in $(ls arch/sbin); do
+       system-docker cp wonka.sh console:/sbin/$i
     done
 }
 
@@ -89,27 +92,26 @@ fi
 cd /dist/spl
 sh ./autogen.sh
 ./configure \
-          --exec-prefix=/dist/arch \
           --with-linux=${DIR}
 make -s -j$(nproc)
 
 cd /dist/zfs
 sh ./autogen.sh
 ./configure \
-          --exec-prefix=/dist/arch \
           --with-linux=${DIR}
 make -s -j$(nproc)
 
 # last layer - we could use stratos :)
 cd /dist/spl
-make install
+make DESTDIR=/dist/arch install
 cd /dist/zfs
-make install
+make DESTDIR=/dist/arch install
 cd /dist
 
 depmod
 
 cp /dist/Dockerfile.zfs-tools /dist/arch/Dockerfile
+cp /dist/entry.sh /dist/arch/
 system-docker build -t zfs-tools arch/
 
 setupconsolecommands

--- a/images/20-zfs/entry.sh
+++ b/images/20-zfs/entry.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+mount --rbind /host/dev /dev
+exec "$@"

--- a/images/20-zfs/wonka.sh
+++ b/images/20-zfs/wonka.sh
@@ -5,4 +5,6 @@ exec system-docker run --rm -it --privileged \
                 --net host \
                 --ipc host \
 		-v /mnt:/mnt:shared \
+		-v /dev:/host/dev \
+		-v /run:/run \
 		zfs-tools $(basename $0) $@

--- a/z/zfs.yml
+++ b/z/zfs.yml
@@ -12,7 +12,6 @@ zfs:
 #  - /usr/bin/ros:/usr/bin/ros
   volumes_from:
   - all-volumes
-  restart: always
   pid: host
   ipc: host
   net: host


### PR DESCRIPTION
* Make ZFS tools bind mount /run and /dev.  This is needed to access udev
  and newly created devices (during zpool create).
* Switch to make DESTDIR=... to ensure all programs are installed.
  Specfically /sbin/mount.zfs was missing.  Also note that mount.zfs
  must be in /sbin (and not /usr/local/sbin) or it won't be found by
  zpool create and possibly other tools.