### PR TITLE
Use the correct docker 1.13.X version in index.yml

### DIFF
--- a/index.yml
+++ b/index.yml
@@ -15,4 +15,4 @@ engines:
 - docker-1.10.3
 - docker-1.11.2
 - docker-1.12.6
-- docker-1.13.0
+- docker-1.13.1


### PR DESCRIPTION
Docker 1.13.0 is not available as service yml, currently docker 1.13.1 is available only.

Fixes rancher/os#1607