### PR TITLE
Always use system-docker for kernel modules&headers - that way they c…

### DIFF
--- a/k/kernel-extras.yml
+++ b/k/kernel-extras.yml
@@ -3,6 +3,7 @@ kernel-extras:
   labels:
     io.rancher.os.detach: false
     io.rancher.os.after: network
+    io.rancher.os.scope: system
   volumes:
   - /usr/src:/usr/src
   - /lib/modules:/lib/modules

--- a/k/kernel-headers-system-docker.yml
+++ b/k/kernel-headers-system-docker.yml
@@ -1,3 +1,5 @@
+# this is deprecated - as we're installing into the host OS, it makes more sense
+# for them to be able to bootstrap your system to be able to start the user docker
 kernel-headers-system-docker:
   image: rancher/os-headers:${KERNEL_VERSION}${SUFFIX}
   labels:

--- a/k/kernel-headers.yml
+++ b/k/kernel-headers.yml
@@ -3,6 +3,7 @@ kernel-headers:
   labels:
     io.rancher.os.detach: false
     io.rancher.os.after: network
+    io.rancher.os.scope: system
   volumes:
   - /usr/src:/usr/src
   - /lib/modules:/lib/modules


### PR DESCRIPTION
…an be used to bootstrap to a working user-docker

https://github.com/rancher/os/issues/1619

need to find a way to deprecate kernel-headers-system-docker

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>