### PR TITLE
add /mnt and /media shared mounts to the consoles

### DIFF
--- a/a/alpine.yml
+++ b/a/alpine.yml
@@ -9,6 +9,9 @@ console:
     io.rancher.os.console: alpine
   volumes_from:
   - all-volumes
+  volumes:
+  - /media:/media:shared
+  - /mnt:/mnt:shared
   restart: always
   pid: host
   ipc: host

--- a/c/centos.yml
+++ b/c/centos.yml
@@ -9,6 +9,9 @@ console:
     io.rancher.os.console: centos
   volumes_from:
   - all-volumes
+  volumes:
+  - /media:/media:shared
+  - /mnt:/mnt:shared
   restart: always
   pid: host
   ipc: host

--- a/d/debian.yml
+++ b/d/debian.yml
@@ -9,6 +9,9 @@ console:
     io.rancher.os.console: debian
   volumes_from:
   - all-volumes
+  volumes:
+  - /media:/media:shared
+  - /mnt:/mnt:shared
   restart: always
   pid: host
   ipc: host

--- a/f/fedora.yml
+++ b/f/fedora.yml
@@ -9,6 +9,9 @@ console:
     io.rancher.os.console: fedora
   volumes_from:
   - all-volumes
+  volumes:
+  - /media:/media:shared
+  - /mnt:/mnt:shared
   restart: always
   pid: host
   ipc: host

--- a/images/20-zfs/wonka.sh
+++ b/images/20-zfs/wonka.sh
@@ -5,6 +5,7 @@ exec system-docker run --rm --privileged \
                 --net host \
                 --ipc host \
 		-v /mnt:/mnt:shared \
+		-v /media:/media:shared \
 		-v /dev:/host/dev \
 		-v /run:/run \
 		zfs-tools $(basename $0) $@

--- a/u/ubuntu.yml
+++ b/u/ubuntu.yml
@@ -9,6 +9,9 @@ console:
     io.rancher.os.console: ubuntu
   volumes_from:
   - all-volumes
+  volumes:
+  - /media:/media:shared
+  - /mnt:/mnt:shared
   restart: always
   pid: host
   ipc: host

--- a/x/xfce.yml
+++ b/x/xfce.yml
@@ -8,6 +8,9 @@ console:
     io.rancher.os.console: xfce
   volumes_from:
   - all-volumes
+  volumes:
+  - /media:/media:shared
+  - /mnt:/mnt:shared
   restart: always
   pid: host
   ipc: host


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

https://github.com/rancher/os/issues/1615

I presume to v0.9.0 these should be moved to a `media-volumes`  which gets added to `all-volumes` - kinda surprising that this wasn't an issue in 0.7.