### PR TITLE
fix zfs build mv failure

### DIFF
--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -35,9 +35,9 @@ VERSION="0.6.5.9"
 curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/spl-${VERSION}.tar.gz > spl-${VERSION}.tar.gz
 curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/zfs-${VERSION}.tar.gz > zfs-${VERSION}.tar.gz
 tar zxvf spl-${VERSION}.tar.gz
-mv spl-${VERSION} spl
+mv spl-${VERSION}/ spl/
 tar zxvf zfs-${VERSION}.tar.gz
-mv zfs-${VERSION} zfs
+mv zfs-${VERSION}/ zfs/
 
 #if [ -d "spl" ]; then
 #   cd spl


### PR DESCRIPTION
if the build is interrupted and re-ran, the build.sh script tries to move the spl-{version} directory (not just it's contents) inside of directory spl, instead of renaming it to spl, so you get spl/spl-{version}. this stops the build in it's tracks no matter how many times it is restarted. this commit makes it so the contents of spl-{version} are simply moved on top of spl if it already exists, or renames spl-{version} to spl as intended if not.