### PR TITLE
Added volume-netshare drivers and AWS metadata provider

### DIFF
--- a/a/amazon-metadata.yml
+++ b/a/amazon-metadata.yml
@@ -1,0 +1,19 @@
+amazon-metadata:
+  image: rancher/os-amazon-metadata:v0.9.2${SUFFIX}
+  command: -m
+  pid: host
+  ipc: host
+  net: host
+  uts: host
+  privileged: true
+  labels:
+    io.rancher.os.after: network
+    io.rancher.os.before: console
+    io.rancher.os.detach: "false"
+    io.rancher.os.scope: system
+    io.rancher.os.reloadconfig: "true"
+  volumes:
+    - /usr/bin/ros:/bin/ros:ro
+    - /var/lib/rancher/conf:/var/lib/rancher/conf:rw
+  environment:
+    - AWS_*

--- a/images/20-amazon-metadata/Dockerfile
+++ b/images/20-amazon-metadata/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:latest
+RUN apk -Uuv add bash jq ca-certificates groff less python py-pip && \
+	pip install awscli && \
+	apk --purge -v del py-pip && \
+	rm /var/cache/apk/*
+
+ADD ./entry.sh /entry.sh
+ADD ./ec2-metadata /lib/ec2-metadata
+RUN chmod +x /*.sh
+
+ENV AWS_METADATA_LOAD "true"
+ENV AWS_METADATA_TAG_PREFIXES "docker."
+ENV AWS_METADATA_TAG_VARIABLES ""
+
+ENTRYPOINT [ "/entry.sh" ]

--- a/images/20-amazon-metadata/README.md
+++ b/images/20-amazon-metadata/README.md
@@ -1,3 +1,5 @@
+Based on code from https://github.com/efim-a-efim/rancheros-ec2-metadata
+
 # AWS EC2 Metadata provider for RancherOS
 
 Intended to use with Autoscaling.
@@ -55,3 +57,8 @@ rancher:
 * `-t [prefix]` - load EC2 instance tags starting with `prefix` and add them as labels to docker daemon options
 * `-l label:variablename` - add `variablename` variable to RancherOS environment that contains value of `label` tag. May be used multiple times
 * `-l label:config.path` - add value of `label` tag to `config.path` RancherOS config path. Works when `config.path` has `.` inside.
+
+### Configuration environment variables
+* `AWS_METADATA_LOAD` (`true`|`false`) - load metadata from AWS and add corresponding environment variables. See `-m` above.
+* `AWS_METADATA_TAG_PREFIXES` (list, separated by `;`) - see `-t` above
+* `AWS_METADATA_TAG_VARIABLES` (list, separated by `;`) - see `-l` for variables above

--- a/images/20-amazon-metadata/README.md
+++ b/images/20-amazon-metadata/README.md
@@ -1,0 +1,57 @@
+# AWS EC2 Metadata provider for RancherOS
+
+Intended to use with Autoscaling.
+- Adds AWS EC2 metadata to RancherOS environment
+- Adds instance tags (filtered) to Docker options
+
+## How to use
+
+You can enable the service using cloud-config:
+```
+services_include:
+  amazon-metadata: true
+```
+
+OR you can start it manually like this:
+
+```
+#cloud-config
+rancher:
+  services:
+    aws-metadata:
+      image: rancher/os-amazon-metadata:v0.9.2${SUFFIX}
+      command: -m -t 'com.' -l 'com.environment:ENVIRONMENT'
+      privileged: true
+      labels:
+        io.rancher.os.after: network
+        io.rancher.os.scope: system
+        io.rancher.os.reloadconfig: 'true'
+        io.rancher.os.createonly: 'false'
+      volumes:
+        - /usr/bin/ros:/bin/ros:ro
+        - /var/lib/rancher/conf:/var/lib/rancher/conf:rw
+```
+
+### Options:
+* `-m` - put AWS metadata to the Rancher environment vars. Metadata supported:
+  * AWS_AVAILABILITY_ZONE
+  * AWS_DEFAULT_REGION
+  * AWS_IAM_ROLE
+  * AWS_ACCESS_KEY_ID
+  * AWS_SECRET_ACCESS_KEY
+  * AWS_SECURITY_TOKEN
+  * AWS_INSTANCE_ID
+  * AWS_AMI_ID
+  * AWS_AMI_LAUNCH_INDEX
+  * AWS_AMI_MANIFEST_PATH
+  * AWS_ANCESTOR_AMI_IDS
+  * AWS_HOSTNAME
+  * AWS_LOCAL_HOSTNAME
+  * AWS_INSTANCE_ACTION
+  * AWS_INSTANCE_TYPE
+  * AWS_LOCAL_IPV4
+  * AWS_PUBLIC_IPV4
+  * AWS_SECURITY_GROUPS
+* `-t [prefix]` - load EC2 instance tags starting with `prefix` and add them as labels to docker daemon options
+* `-l label:variablename` - add `variablename` variable to RancherOS environment that contains value of `label` tag. May be used multiple times
+* `-l label:config.path` - add value of `label` tag to `config.path` RancherOS config path. Works when `config.path` has `.` inside.

--- a/images/20-amazon-metadata/ec2-metadata/ec2-metadata.sh
+++ b/images/20-amazon-metadata/ec2-metadata/ec2-metadata.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+echo "#cloud-config"
+echo "rancher:"
+echo "  environment:"
+
+echo "    AWS_AVAILABILITY_ZONE: ${AWS_AVAILABILITY_ZONE}"
+echo "    AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION}"
+
+if [ "${AWS_IAM_ROLE}" ]; then
+  echo "    AWS_IAM_ROLE: ${AWS_IAM_ROLE}"
+  echo "    AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}"
+  echo "    AWS_SECRET_ACCESS_KE: ${AWS_SECRET_ACCESS_KEY}"
+  echo "    AWS_SECURITY_TOKEN: ${AWS_SECURITY_TOKEN}"
+fi
+echo "    AWS_INSTANCE_ID: ${AWS_INSTANCE_ID}"
+
+echo "    AWS_AMI_ID: $(wget -O- -q "http://169.254.169.254/latest/meta-data/ami-id" 2>/dev/null)"
+echo "    AWS_AMI_LAUNCH_INDEX: $(wget -O- -q "http://169.254.169.254/latest/meta-data/ami-launch-index" 2>/dev/null)"
+echo "    AWS_AMI_MANIFEST_PATH: $(wget -O- -q "http://169.254.169.254/latest/meta-data/ami-manifest-path" 2>/dev/null)"
+echo "    AWS_ANCESTOR_AMI_IDS: $(wget -O- -q "http://169.254.169.254/latest/meta-data/ancestor-ami-ids" 2>/dev/null)"
+echo "    AWS_HOSTNAME: $(wget -O- -q "http://169.254.169.254/latest/meta-data/hostname" 2>/dev/null)"
+echo "    AWS_LOCAL_HOSTNAME: $(wget -O- -q "http://169.254.169.254/latest/meta-data/local-hostname" 2>/dev/null)"
+echo "    AWS_INSTANCE_ACTION: $(wget -O- -q "http://169.254.169.254/latest/meta-data/instance-action" 2>/dev/null)"
+
+echo "    AWS_INSTANCE_TYPE: $(wget -O- -q "http://169.254.169.254/latest/meta-data/instance-type" 2>/dev/null)"
+echo "    AWS_LOCAL_IPV4: $(wget -O- -q "http://169.254.169.254/latest/meta-data/local-ipv4" 2>/dev/null)"
+echo "    AWS_PUBLIC_IPV4: $(wget -O- -q "http://169.254.169.254/latest/meta-data/public-ipv4" 2>/dev/null)"
+echo "    AWS_SECURITY_GROUPS: $(wget -O- -q "http://169.254.169.254/latest/meta-data/security-groups" 2>/dev/null)"

--- a/images/20-amazon-metadata/ec2-metadata/ec2-tag-to-env.sh
+++ b/images/20-amazon-metadata/ec2-metadata/ec2-tag-to-env.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+INSTANCE="${1}"
+label=$(echo "$2" | cut -d ':' -f 1)
+var=$(echo "$2" | cut -d ':' -f 2-)
+
+if [ -z "${label}" -o -z "${var}" ]; then
+  echo "Bad args format"
+  exit 1
+fi
+
+echo "#cloud-config"
+echo "rancher:"
+echo "  environment:"
+
+TAG_VAL=$(aws ec2 describe-tags --region "${AWS_DEFAULT_REGION}" --filters "Name=key,Values=${label}" "Name=resource-id,Values=${INSTANCE}" 2>/dev/null | jq -r -j ".Tags[] | \"\(.Value)\"" 2>/dev/null)
+
+echo "    ${var}: ${TAG_VAL}"

--- a/images/20-amazon-metadata/ec2-metadata/ec2-tags.sh
+++ b/images/20-amazon-metadata/ec2-metadata/ec2-tags.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+INSTANCE="${1}"
+TAG_FILTER=''
+[ "$2" ] && TAG_FILTER="| select(.Key|startswith(\"${2}\"))"
+
+echo "#cloud-config"
+echo "rancher:"
+echo "  docker:"
+echo "    args:"
+
+ros config get rancher.docker.args | grep -v '\[\]' | grep -v '^\s*$' | sed 's/^/      /'
+
+aws ec2 describe-tags --region "${AWS_DEFAULT_REGION}" --filters "Name=resource-id,Values=${INSTANCE}" 2>/dev/null \
+  | jq -r ".Tags[] ${TAG_FILTER} | \"\(.Key)=\(.Value)\"" 2>/dev/null \
+  | while read label; do
+    echo "      - --label"
+    echo "      - ${label}"
+  done

--- a/images/20-amazon-metadata/ec2-metadata/set-config.sh
+++ b/images/20-amazon-metadata/ec2-metadata/set-config.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[ -f "$1" ] || exit 1
+
+ros config merge < "${1}"

--- a/images/20-amazon-metadata/entry.sh
+++ b/images/20-amazon-metadata/entry.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+LIB_PATH="/lib/ec2-metadata"
+
+# Basic metadata
+export AWS_AVAILABILITY_ZONE="$(wget -O- -q http://169.254.169.254/latest/meta-data/placement/availability-zone 2>/dev/null)"
+export AWS_DEFAULT_REGION="${AWS_AVAILABILITY_ZONE%?}"
+export AWS_IAM_ROLE="$(wget -O- -q "http://169.254.169.254/latest/meta-data/iam/info" 2>/dev/null | grep 'InstanceProfileArn' | tr -d ' ",' | cut -d '/' -f 2)"
+if [ "${AWS_IAM_ROLE}" ]; then
+  export AWS_ACCESS_KEY_ID="$(wget -O- -q "http://169.254.169.254/latest/meta-data/iam/security-credentials/${AWS_IAM_ROLE}" 2>/dev/null | grep 'AccessKeyId' | tr -d ' ",' | cut -d ':' -f 2)"
+  export AWS_SECRET_ACCESS_KEY="$(wget -O- -q "http://169.254.169.254/latest/meta-data/iam/security-credentials/${AWS_IAM_ROLE}" 2>/dev/null | grep 'SecretAccessKey' | tr -d ' ",' | cut -d ':' -f 2)"
+  export AWS_SECURITY_TOKEN="$(wget -O- -q "http://169.254.169.254/latest/meta-data/iam/security-credentials/${AWS_IAM_ROLE}" 2>/dev/null | grep 'Token' | tr -d ' ",' | cut -d ':' -f 2)"
+fi
+export AWS_INSTANCE_ID="$(wget -O- -q "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null)"
+
+while getopts ':t:e:m' opt; do
+  case "$opt" in
+    t)
+      bash "${LIB_PATH}/ec2-tags.sh" "${AWS_INSTANCE_ID}" "${OPTARG}"  | ros config merge
+      ;;
+    m)
+      bash "${LIB_PATH}/ec2-metadata.sh" | ros config merge
+      ;;
+    e)
+      bash "${LIB_PATH}/ec2-tag-to-env.sh" "${AWS_INSTANCE_ID}" "${OPTARG}" | ros config merge
+      ;;
+    ?)
+      echo "Unsupported option -$OPTARG"
+      ;;
+    :)
+      case "$OPTARG" in
+        t)
+          bash "${LIB_PATH}/ec2-tags.sh" "${AWS_INSTANCE_ID}" 'docker.' | ros config merge
+          ;;
+        *)
+          echo "Argument required for -$OPTARG"
+          ;;
+      esac
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
+if [ "${AWS_METADATA_LOAD}" = 'true' ]; then
+  bash "${LIB_PATH}/ec2-metadata.sh" | ros config merge
+fi
+
+if [ "${AWS_METADATA_TAG_PREFIXES}" ]; then
+  echo "${AWS_METADATA_TAG_PREFIXES}" | while read -d ';' tag; do
+    bash "${LIB_PATH}/ec2-tags.sh" "${AWS_INSTANCE_ID}" "${tag}" | ros config merge
+  done
+fi
+
+if [ "${AWS_METADATA_TAG_VARIABLES}" ]; then
+  echo "${AWS_METADATA_TAG_VARIABLES}" | while read -d ';' tag; do
+    bash "${LIB_PATH}/ec2-tag-to-env.sh" "${AWS_INSTANCE_ID}" "${tag}" | ros config merge
+  done
+fi

--- a/images/20-volume-netshare/Dockerfile
+++ b/images/20-volume-netshare/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:latest
+
+ARG netshare_plugin_version 0.19
+
+RUN apk add --update wget nfs-utils ca-certificates &&\
+    rm -rf /var/cache/apk/* &&\
+    update-ca-certificates
+
+RUN wget -O /usr/bin/docker-volume-netshare https://github.com/ContainX/docker-volume-netshare/releases/download/v${netshare_plugin_version}/docker-volume-netshare_${netshare_plugin_version}_linux_amd64-bin \
+&& chmod +x /usr/bin/docker-volume-netshare
+
+ENTRYPOINT ["/usr/bin/docker-volume-netshare"]
+CMD ["efs"]

--- a/images/20-volume-netshare/README.md
+++ b/images/20-volume-netshare/README.md
@@ -1,0 +1,32 @@
+# docker-volume-netshare in container
+
+You can enable the service using cloud-config (use corresponding volume type or enable all):
+```
+services_include:
+  volume-efs: true
+  volume-nfs: true
+  volume-cifs: true
+```
+
+Additional options may be specified through environment:
+* `VOLUME_CIFS_OPTIONS`
+* `VOLUME_EFS_OPTIONS`
+* `VOLUME_NFS_OPTIONS`
+
+## AWS EFS
+
+Add following settings to your cloud-config:
+```
+services_include:
+  amazon-metadata: true
+  volume-efs: true
+```
+
+Use Docker volumes:
+```
+my-application:
+  image: me/my-application
+  volume_driver: efs
+  volumes:
+    - fs-XXyyZZtt:/data
+```

--- a/index.yml
+++ b/index.yml
@@ -6,6 +6,8 @@ services:
 - kernel-headers-system-docker
 - open-vm-tools
 - zfs
+- amazon-metadata
+- volume-netshare
 consoles:
 - alpine
 - centos

--- a/v/volume-cifs.yml
+++ b/v/volume-cifs.yml
@@ -1,0 +1,19 @@
+volume-cifs:
+  command: cifs --verbose --basedir=/mnt ${VOLUME_CIFS_OPTIONS}
+  image: rancher/os-volume-netshare:v0.9.2${SUFFIX}
+  pid: host
+  ipc: host
+  net: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes:
+    - /run/docker/plugins:/run/docker/plugins:rw
+    - /mnt/volumes/netshare/cifs:/mnt:shared
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: docker
+    io.rancher.os.detach: "true"
+  environment:
+    - AWS_*
+    - VOLUME_CIFS_OPTIONS

--- a/v/volume-efs.yml
+++ b/v/volume-efs.yml
@@ -1,0 +1,19 @@
+volume-efs:
+  command: efs --verbose --basedir=/mnt ${VOLUME_EFS_OPTIONS}
+  image: rancher/os-volume-netshare:v0.9.2${SUFFIX}
+  pid: host
+  ipc: host
+  net: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes:
+    - /run/docker/plugins:/run/docker/plugins:rw
+    - /mnt/volumes/netshare/efs:/mnt:shared
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: docker
+    io.rancher.os.detach: "true"
+  environment:
+    - AWS_*
+    - VOLUME_EFS_OPTIONS

--- a/v/volume-nfs.yml
+++ b/v/volume-nfs.yml
@@ -1,0 +1,19 @@
+volume-nfs:
+  command: nfs --verbose --basedir=/mnt ${VOLUME_NFS_OPTIONS}
+  image: rancher/os-volume-netshare:v0.9.2${SUFFIX}
+  pid: host
+  ipc: host
+  net: host
+  uts: host
+  privileged: true
+  restart: always
+  volumes:
+    - /run/docker/plugins:/run/docker/plugins:rw
+    - /mnt/volumes/netshare/nfs:/mnt:shared
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: docker
+    io.rancher.os.detach: "true"
+  environment:
+    - AWS_*
+    - VOLUME_NFS_OPTIONS


### PR DESCRIPTION
Fixes rancher/os#1775

Added new services:

## amazon-metadata
Fetches Amazon AWS metadata and some other data (see [README](images/20-amazon-metadata/README.md)) and puts them to config.

## volume-netshare
Volume driver for network volumes: https://github.com/ContainX/docker-volume-netshare
Added system services for each volume type:
* volune-efs
* volume-cifs
* volume-nfs

See [README](images/20-volume-netshare/README.md) for details.