### PR TITLE
Add open-iscsi support

### DIFF
--- a/i/iscsi.yml
+++ b/i/iscsi.yml
@@ -1,0 +1,21 @@
+open-iscsi:
+  image: rancher/os-iscsi:latest
+  command: ./build.sh
+  privileged: "true"
+  labels:
+    io.rancher.os.scope: "system"
+    io.rancher.os.detach: "false"
+    io.rancher.os.before: "docker"
+    io.rancher.os.after: "console"
+  environment:
+  - HTTP_PROXY
+  - HTTPS_PROXY
+  - NO_PROXY
+  volumes:
+  - /usr/src:/usr/src
+  volumes_from:
+  - all-volumes
+  pid: host
+  ipc: host
+  net: host
+  uts: host

--- a/images/20-iscsi/Dockerfile
+++ b/images/20-iscsi/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:16.04
+# FROM arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get install -yq curl \
+	build-essential autoconf libtool \
+	module-init-tools \
+	libssl-dev \
+	libmount-dev
+
+WORKDIR /dist
+COPY entry.sh /dist/
+COPY build.sh /dist/
+COPY wonka.sh /dist/
+COPY Dockerfile.iscsi-tools /dist/
+
+CMD ["/dist/build.sh"]
+
+ENTRYPOINT ["/usr/bin/ros", "entrypoint"]

--- a/images/20-iscsi/Dockerfile.iscsi-tools
+++ b/images/20-iscsi/Dockerfile.iscsi-tools
@@ -1,0 +1,21 @@
+FROM ubuntu:16.04
+# FROM arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
+
+RUN apt-get update \
+    && apt-get install -yq \
+	libssl1.0.0 \
+	libmount1
+
+ADD entry.sh /usr/local/bin/
+ADD sbin/* /sbin/
+ADD etc/iscsi/ /etc/iscsi/
+ADD etc/isns/ /etc/isns/
+ADD usr/local/sbin/* /usr/local/sbin/
+#ADD usr/local/bin/* /usr/local/bin/
+ADD usr/local/lib/* /usr/local/lib/
+#ADD usr/local/libexec/* /usr/local/libexec/
+ADD setup_wonka.sh /setup_wonka.sh
+
+RUN mkdir -p /run/lock
+
+ENTRYPOINT ["/usr/local/bin/entry.sh"]

--- a/images/20-iscsi/build.sh
+++ b/images/20-iscsi/build.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+set -ex
+
+
+KERNEL_VERSION=$(uname -r)
+echo "open-iscsi for ${KERNEL_VERSION}"
+
+DIR=/lib/modules/${KERNEL_VERSION}/build
+STAMP=/lib/modules/${KERNEL_VERSION}/.open-iscsi-done
+
+if [ -e $STAMP ]; then
+    modprobe iscsi_tcp
+    system-docker run --rm iscsi-tools cat /setup_wonka.sh > /setup_wonka.sh
+    chmod 755 /setup_wonka.sh
+    # setup wonka in the console container
+    /setup_wonka.sh console
+    # setup wonka in this container so the import works
+    /setup_wonka.sh iscsi-tools
+
+    echo open-iscsi for ${KERNEL_VERSION} already installed. Delete $STAMP to reinstall
+    exit 0
+fi
+
+#TODO: test that the headers are there
+#TODO: or, if we continue to be able to use the docker daemon, can we use ros to enable and up it?
+ros service enable kernel-headers-system-docker
+ros service up kernel-headers-system-docker
+
+
+VERSION="0.97"
+curl -sL https://github.com/open-iscsi/open-isns/archive/v${VERSION}.tar.gz > open-isns${VERSION}.tar.gz
+tar zxvf open-isns${VERSION}.tar.gz
+rm -rf /dist/isns
+mv open-isns-${VERSION}/ /dist/isns/
+
+VERSION="2.0.874"
+curl -sL https://github.com/open-iscsi/open-iscsi/archive/${VERSION}.tar.gz > open-iscsi${VERSION}.tar.gz
+tar zxvf open-iscsi${VERSION}.tar.gz
+rm -rf /dist/iscsi
+mv open-iscsi-${VERSION}/ /dist/iscsi/
+
+cd /dist/isns
+./configure
+make -s -j$(nproc)
+make install
+make install_hdrs
+make install_lib
+
+cd /dist/iscsi
+make -s -j$(nproc)
+make install
+
+# last layer - we could use stratos :)
+cd /dist/isns
+make DESTDIR=/dist/arch install
+cd /dist/iscsi
+make DESTDIR=/dist/arch install
+cd /dist
+
+cp /dist/Dockerfile.iscsi-tools /dist/arch/Dockerfile
+cp /dist/entry.sh /dist/arch/
+
+# how do I export the commands to the console?
+# in the future, it'd be nice to have some share /usr/local/bin, but that might interfere with other things.
+# we do seem to have /opt mapped
+echo "#!/bin/sh" > /dist/arch/setup_wonka.sh
+echo "echo installing wonka bin links in \${1}" >> /dist/arch/setup_wonka.sh
+chmod 755 /dist/arch/setup_wonka.sh
+#for i in $(ls arch/usr/local/bin); do
+#   echo "system-docker cp wonka.sh \${1}:/usr/bin/$i" >> /dist/arch/setup_wonka.sh
+#done
+for i in $(ls arch/usr/local/sbin); do
+   echo "system-docker cp wonka.sh \${1}:usr/sbin/$i" >> /dist/arch/setup_wonka.sh
+done
+for i in $(ls arch/sbin); do
+   echo "system-docker cp wonka.sh \${1}:/sbin/$i" >> /dist/arch/setup_wonka.sh
+done
+chmod 755 /dist/arch/setup_wonka.sh
+system-docker build -t iscsi-tools arch/
+
+modprobe iscsi_tcp
+
+# setup wonka in the console container
+/dist/arch/setup_wonka.sh console
+
+touch $STAMP
+echo open-iscsi for ${KERNEL_VERSION} installed. Delete $STAMP to reinstall

--- a/images/20-iscsi/entry.sh
+++ b/images/20-iscsi/entry.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mount --rbind /host/dev /dev > /dev/null 2>&1
+mkdir -p /run/lock
+exec "$@"

--- a/images/20-iscsi/wonka.sh
+++ b/images/20-iscsi/wonka.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+exec system-docker run --rm --privileged \
+                --pid host \
+                --net host \
+                --ipc host \
+		-v /mnt:/mnt:shared \
+		-v /media:/media:shared \
+		-v /dev:/host/dev \
+		-v /run:/run \
+		-v /etc/iscsi/nodes/:/etc/iscsi/nodes/ \
+		-v /etc/iscsi/send_targets/:/etc/iscsi/send_targets/ \
+		iscsi-tools $(basename $0) $@

--- a/index.yml
+++ b/index.yml
@@ -1,6 +1,7 @@
 services:
 - amazon-ecs-agent
 - crontab
+- open-iscsi
 - kernel-extras
 - kernel-headers
 - kernel-headers-system-docker


### PR DESCRIPTION
Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>

It installs, but I haven't set up an iSCSI target and tested that yet.

testing with https://wiki.archlinux.org/index.php/TGT_iSCSI_Target