### PR TITLE
Fix spl and zfs extraction

### DIFF
--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -34,10 +34,10 @@ ros service up kernel-headers-system-docker
 VERSION="0.6.5.9"
 curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/spl-${VERSION}.tar.gz > spl-${VERSION}.tar.gz
 curl -sL https://github.com/zfsonlinux/zfs/releases/download/zfs-${VERSION}/zfs-${VERSION}.tar.gz > zfs-${VERSION}.tar.gz
-tar zxvf spl-${VERSION}.tar.gz
-mv spl-${VERSION}/ spl/
-tar zxvf zfs-${VERSION}.tar.gz
-mv zfs-${VERSION}/ zfs/
+mkdir -p spl
+tar zxvf spl-${VERSION}.tar.gz --strip-components=1 -C spl
+mkdir -p zfs
+tar zxvf zfs-${VERSION}.tar.gz --strip-components=1 -C zfs
 
 #if [ -d "spl" ]; then
 #   cd spl


### PR DESCRIPTION
This would allow one to specify a test version of spl/zfs and have it work. i.e. `0.7.0-rc4`.
Test versions are otherwise extracted folders without `-rc4` part which would make the `mv` command fail, so extracting straight into `spl` and `zfs` will work around that problem.