### PR TITLE
Update open-vm-tools to 2:10.1.5-5055683-4 - switch to debian base as…

### DIFF
--- a/images/10-openvmtools/Dockerfile
+++ b/images/10-openvmtools/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.10
+FROM debian:stretch-slim
 # FROM arm=skip arm64=skip
 
 # net-tools for ifconfig, iproute for ip


### PR DESCRIPTION
… its more up to date

Signed-off-by: Sven Dowideit <SvenDowideit@home.org.au>