### PR TITLE
Use proper quoting.

### DIFF
--- a/images/20-zfs/wonka.sh
+++ b/images/20-zfs/wonka.sh
@@ -8,4 +8,4 @@ exec system-docker run --rm --privileged \
 		-v /media:/media:shared \
 		-v /dev:/host/dev \
 		-v /run:/run \
-		zfs-tools $(basename $0) $@
+		zfs-tools "$(basename $0)" "$@"


### PR DESCRIPTION
Fixes an issue with commands like: `zfs create "tank/this has spaces"`, and also reduces risk of injected commands e.g. `zfs ; rm -rf /`.