### PR TITLE
Change ecs directory

### DIFF
--- a/a/amazon-ecs-agent.yml
+++ b/a/amazon-ecs-agent.yml
@@ -4,7 +4,7 @@ ecs-agent:
   volumes:
   - /var/run/:/var/run/
   - /var/log/ecs/:/log
-  - /var/lib/ecs/data:/data
+  - /opt/var/lib/ecs/data:/data
   - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - /var/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro
   ports:
@@ -14,5 +14,6 @@ ecs-agent:
   - ECS_LOGFILE=/log/ecs-agent.log
   - ECS_LOGLEVEL=info
   - ECS_DATADIR=/data
+  - ECS_HOST_DATA_DIR=/opt/var/lib/ecs
   - ECS_*
   - AWS_*


### PR DESCRIPTION
According the [ecs docs:](https://github.com/aws/amazon-ecs-agent/blob/master/README.md#persistence)
1. `ecs` directory change to `/opt/var/lib/ecs`
2. `ecs-agent` need configure `ECS_HOST_DATA_DIR` environment
> `ECS_HOST_DATA_DIR` is to determine the source mount path for container metadata files in the case the ECS Agent is running as a container. The default value is `/var/lib/ecs`, so I think this also needs to be  changed


rancher/os#2394