### PR TITLE
Add virtualbox-tools support

### DIFF
--- a/images/10-virtualboxtools/Dockerfile
+++ b/images/10-virtualboxtools/Dockerfile
@@ -1,0 +1,44 @@
+FROM gcc:7.3.0 as build-essential
+ENV KERNEL_VERSION 4.14.85-rancher
+
+ENV KERNEL_HEADERS https://github.com/rancher/os-kernel/releases/download/v${KERNEL_VERSION}/build-linux-${KERNEL_VERSION}-x86.tar.gz
+ENV KERNEL_BASE https://github.com/rancher/os-kernel/releases/download/v${KERNEL_VERSION}/linux-${KERNEL_VERSION}-x86.tar.gz
+ENV VBOX_VERSION 5.2.22
+ENV VBOX_SHA256 e51e33500a265b5c2d7bb2d03d32208df880523dfcb1e2dde2c78a0e0daa0603
+
+RUN apt-get update; \
+	apt-get install -y --no-install-recommends p7zip-full libelf-dev; \
+	apt-get clean; \
+	rm -rf /var/lib/apt/*
+RUN mkdir -p /usr/src/v${KERNEL_VERSION}; \
+	curl -sfL ${KERNEL_BASE} | tar zxf - -C /; \
+	curl -sfL ${KERNEL_HEADERS} | tar zxf - -C /usr/src/v${KERNEL_VERSION}
+RUN wget -O /vbox.iso "https://download.virtualbox.org/virtualbox/$VBOX_VERSION/VBoxGuestAdditions_$VBOX_VERSION.iso"; \
+	echo "$VBOX_SHA256 */vbox.iso" | sha256sum -c -; \
+	7z x -o/ /vbox.iso VBoxLinuxAdditions.run; \
+	rm /vbox.iso; \
+	sh /VBoxLinuxAdditions.run --noexec --target /usr/src/vbox; \
+	mkdir /usr/src/vbox/amd64; \
+	7z x -so /usr/src/vbox/VBoxGuestAdditions-amd64.tar.bz2 | tar --extract --directory /usr/src/vbox/amd64; \
+	rm /usr/src/vbox/VBoxGuestAdditions-*.tar.bz2; \
+	ln -sT "vboxguest-$VBOX_VERSION" /usr/src/vbox/amd64/src/vboxguest
+RUN make -C /usr/src/vbox/amd64/src/vboxguest -j "$(nproc)" \
+	KERN_DIR='/lib/modules/${KERNEL_VERSION}/build' \
+	KERN_VER=${KERNEL_VERSION} \
+	vboxguest vboxsf 
+
+FROM debian:stable-slim
+WORKDIR /dist
+RUN apt-get update; \
+        apt-get install -y --no-install-recommends kmod; \
+        apt-get clean; \
+        rm -rf /var/lib/apt/*
+COPY run /usr/local/bin/
+COPY --from=build-essential /usr/src/vbox/amd64/src/vboxguest/vboxguest.ko .
+COPY --from=build-essential /usr/src/vbox/amd64/src/vboxguest/vboxsf.ko .
+COPY --from=build-essential /usr/src/vbox/amd64/other/mount.vboxsf .
+COPY --from=build-essential /usr/src/vbox/amd64/sbin/VBoxService .
+COPY --from=build-essential /usr/src/vbox/amd64/bin/VBoxControl .
+RUN chmod +x /usr/local/bin/run
+
+CMD ["/usr/local/bin/run"]

--- a/images/10-virtualboxtools/run
+++ b/images/10-virtualboxtools/run
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+_sigProcess() {
+    echo "SIGINT/SIGTERM signal..."
+    kill -9 $vboxServicePID
+    wait
+    kill -9 $$
+}
+trap _sigProcess SIGINT SIGKILL SIGTERM
+
+kernel_dir=/lib/modules/`uname -r`
+if [ ! -d $kernel_dir/extra ];then
+    mkdir $kernel_dir/extra
+else
+    echo "Directory $kernel_dir/extra already exists."
+fi
+
+lsmod | grep "vboxsf" > /dev/null 2>&1
+if [ $? -ne 0 ];then
+    cp /dist/*.ko $kernel_dir/extra
+    depmod
+    modprobe vboxguest
+    modprobe vboxsf
+else
+    echo "Vbox modules have been loaded."
+fi
+
+for _ in {1..10}
+do
+    if [ -f /run/console-done ];then
+        system-docker exec console ls /sbin/mount.vboxsf  > /dev/null 2>&1
+        if [ $? -ne 0 ];then
+            system-docker cp /dist/mount.vboxsf console:/sbin/
+        else
+            echo "/sbin/mount.vboxsf already exists."
+        fi
+        break
+    else
+        echo "Waiting for the console to start ..."
+        sleep 2
+    fi
+done
+
+/sbin/VBoxService --disable-automount --foreground --disable-vminfo &
+vboxServicePID=$!
+
+wait

--- a/index.yml
+++ b/index.yml
@@ -18,6 +18,7 @@ services:
 - volume-nfs
 - modem-manager
 - waagent
+- virtualbox-tools
 consoles:
 - alpine
 - centos

--- a/v/virtualbox-tools.yml
+++ b/v/virtualbox-tools.yml
@@ -1,0 +1,14 @@
+virtualbox-tools:
+  image: ${REGISTRY_DOMAIN}/rancher/os-vboxtools:v5.2.22-1
+  command: /usr/local/bin/run
+  privileged: true
+  labels:
+    io.rancher.os.scope: system
+    io.rancher.os.after: console
+  pid: host
+  ipc: host
+  net: host
+  uts: host
+  volumes_from:
+  - command-volumes
+  - system-volumes


### PR DESCRIPTION
https://github.com/rancher/os/issues/143

## How to use

First, you need to start the `virtualbox-tools` service in rancheros.

```
sudo ros service enable virtualbox-tools
sudo ros service up virtualbox-tools
```
> Note: if you switch consoles, you may need to re-run `ros service restart virtualbox-tools`.

After the `virtualbox-tools` service starts, it will automatically load the vbox module and start the `VBoxService` process.

```
lsmod | grep -i vbox
vboxsf                 49152  0
vboxguest             258048  2 vboxsf

ps -ef | grep VBoxService
root      1898     1  0 09:12 ?        00:00:00 [VBoxService] <defunct>
root      1900     1  0 09:12 ?        00:00:00 /sbin/VBoxService --disable-automount
```
At this point, you can mount the shared folder with `mount.vboxsf test /mnt`. If you want to mount it automatically, you can also do the following:

```
#cloud-config
write_files:
  - path: /etc/rc.local
    permissions: "0755"
    owner: root
    content: |
      #!/bin/bash
      for _ in {1..10}
      do
          if [ -f /sbin/mount.vboxsf ];then
              mount.vboxsf ansible /mnt/ansible
              break
          else
              sleep 1
          fi
      done
```


**Note:**
1. We do not support the auto-mount feature of shared folders.
2. Using `mount.vboxsf` in the alpine console is not yet supported.

