### PR TITLE
add http proxy environment variables to zfs-tools build context

### DIFF
--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -122,19 +122,16 @@ for i in $(ls arch/sbin); do
    echo "system-docker cp wonka.sh \${1}:/sbin/$i" >> /dist/arch/setup_wonka.sh
 done
 
-if [ "XX$HTTP_PROXY" != "XX" ]
-then
-	BUILD_ARGS="--build-arg HTTP_PROXY --build-arg http_proxy="$HTTP_PROXY
+if [ "XX$HTTP_PROXY" != "XX" ]; then
+    BUILD_ARGS="--build-arg HTTP_PROXY --build-arg http_proxy="$HTTP_PROXY
 fi
 
-if [ "XX$HTTPS_PROXY" != "XX" ]
-then
-	BUILD_ARGS=$BUILD_ARGS" --build-arg HTTPS_PROXY --build-arg https_proxy="$HTTPS_PROXY
+if [ "XX$HTTPS_PROXY" != "XX" ]; then
+    BUILD_ARGS=$BUILD_ARGS" --build-arg HTTPS_PROXY --build-arg https_proxy="$HTTPS_PROXY
 fi
 
-if [ "XX$NO_PROXY" != "XX" ]
-then
-	BUILD_ARGS=$BUILD_ARGS" --build-arg NO_PROXY --build-arg no_proxy="$NO_PROXY
+if [ "XX$NO_PROXY" != "XX" ]; then
+    BUILD_ARGS=$BUILD_ARGS" --build-arg NO_PROXY --build-arg no_proxy="$NO_PROXY
 fi
 
 system-docker build --network=host $BUILD_ARGS -t zfs-tools arch/

--- a/images/20-zfs/build.sh
+++ b/images/20-zfs/build.sh
@@ -121,7 +121,23 @@ done
 for i in $(ls arch/sbin); do
    echo "system-docker cp wonka.sh \${1}:/sbin/$i" >> /dist/arch/setup_wonka.sh
 done
-system-docker build --network=host -t zfs-tools arch/
+
+if [ "XX$HTTP_PROXY" != "XX" ]
+then
+	BUILD_ARGS="--build-arg HTTP_PROXY --build-arg http_proxy="$HTTP_PROXY
+fi
+
+if [ "XX$HTTPS_PROXY" != "XX" ]
+then
+	BUILD_ARGS=$BUILD_ARGS" --build-arg HTTPS_PROXY --build-arg https_proxy="$HTTPS_PROXY
+fi
+
+if [ "XX$NO_PROXY" != "XX" ]
+then
+	BUILD_ARGS=$BUILD_ARGS" --build-arg NO_PROXY --build-arg no_proxy="$NO_PROXY
+fi
+
+system-docker build --network=host $BUILD_ARGS -t zfs-tools arch/
 
 modprobe zfs
 


### PR DESCRIPTION
Signed-off-by: Jerome Doucerain <jerome.doucerain@bell.ca>

In case we want to enable and use the RancherOS zfs service when RancherOS is running behind a web proxy, the zfs-tools build command (system-docker build --network=host -t zfs-tools arch/) has to take into account the http_proxy, https_proxy and no_proxy environment variables.
So the pull request is meant to bring the required environment variables to the zfs-tools build command