### PR TITLE
fixes for some build errors in os-services

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,5 +1,5 @@
-FROM ubuntu:16.04
-# FROM arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
+FROM ubuntu:17.10
+# FROM arm64=aarch64/ubuntu:17.10 arm=armhf/ubuntu:17.10
 
 RUN apt-get update && \
     apt-get install -y curl git wget unzip

--- a/images/10-alpineconsole/Dockerfile
+++ b/images/10-alpineconsole/Dockerfile
@@ -20,7 +20,6 @@ RUN apk --no-cache add bash openssh iptables rsync sudo \
     echo 'rancher ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
     echo '## allow password less for docker user' >> /etc/sudoers && \
     echo 'docker ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
-    echo 'ssh-keygen -A' >> /usr/sbin/update-ssh-keys && \
     ln -s /bin/ps /usr/bin/ps && \
     cat /etc/ssh/sshd_config > /etc/ssh/sshd_config.tpl && \
     cat /etc/ssh/sshd_config.append.tpl >> /etc/ssh/sshd_config.tpl && \

--- a/images/10-selinuxtools/prebuild.sh
+++ b/images/10-selinuxtools/prebuild.sh
@@ -5,5 +5,3 @@ cd $(dirname $0)
 
 rm -rf ./build
 mkdir -p ./build
-cp ./../02-console/update-ssh-keys ./build/
-cp ./../02-console/rancheros-install ./build/

--- a/images/20-amazonenadriver/Dockerfile
+++ b/images/20-amazonenadriver/Dockerfile
@@ -1,5 +1,5 @@
-FROM ubuntu:17.04
-# FROM arm64=arm64v8/ubuntu:17.04 arm=arm32v7/ubuntu:17.04
+FROM ubuntu:17.10
+# FROM arm64=arm64v8/ubuntu:17.10 arm=arm32v7/ubuntu:17.10
 
 ENV ENA_VERSION 1.5.0
 

--- a/images/20-iscsi/Dockerfile.iscsi-tools
+++ b/images/20-iscsi/Dockerfile.iscsi-tools
@@ -1,5 +1,5 @@
-FROM ubuntu:16.04
-# FROM arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
+FROM ubuntu:17.10
+# FROM arm64=aarch64/ubuntu:17.10 arm=armhf/ubuntu:17.10
 
 RUN apt-get update \
     && apt-get install -yq \

--- a/images/20-zfs/Dockerfile.zfs-tools
+++ b/images/20-zfs/Dockerfile.zfs-tools
@@ -1,5 +1,5 @@
-FROM ubuntu:16.04
-# FROM arm64=aarch64/ubuntu:16.04 arm=armhf/ubuntu:16.04
+FROM ubuntu:17.10
+# FROM arm64=aarch64/ubuntu:17.10 arm=armhf/ubuntu:17.10
 
 RUN apt-get update \
     && apt-get install -yq python \

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -37,12 +37,12 @@ function build() {
 
     if [[ "$LOCALARCH" != "$ARCH" ]]; then
         echo "${tag} ($LOCALARCH) is not for this arch $ARCH, skipping"
-        continue
+        return
     fi
 
     if docker_tag_exists "${OS_REPO}/${name}" "${version}${SUFFIX}"; then
         echo "${tag} EXISTS on Docker Hub, skipping"
-        continue
+        return
     fi
 
     if [ $(docker images -q ${tag}) ]; then
@@ -67,7 +67,7 @@ function build() {
             exit 1
         else
             echo "Skipping ${tag}"
-            continue
+            return
         fi
     fi
     echo ${tag} >> dist/images

--- a/scripts/build-images
+++ b/scripts/build-images
@@ -57,8 +57,8 @@ function build() {
             ${build_dir}/prebuild.sh "${version}" "${LOCALARCH}"
         fi
 
-        if dapper -d --build -f ${build_dir}/Dockerfile -- -t rancher/${name} ${build_dir}; then
-            docker tag rancher/${name} ${tag}
+        if dapper -d --build -f ${build_dir}/Dockerfile -- -t ${OS_REPO}/${name} ${build_dir}; then
+            docker tag ${OS_REPO}/${name} ${tag}
             if [ "${name}" == "os-docker" ]; then
                 docker run --rm -it ${tag} /engine/docker version | grep Version
                 docker run --rm -it ${tag} /engine/docker version | grep Arch


### PR DESCRIPTION
These are some fixes for build errors I had in os-services:

build-image build() function should use return not continue 
02-console/update-keys does not exist - remove its use
can not use apt-update on Dockerfiles based on ubuntu 17.04 anymore use ubuntu 17.10 instead
