### PR TITLE
[open-iscsi] Fix proxy not forwarded to build

### DIFF
--- a/images/20-iscsi/build.sh
+++ b/images/20-iscsi/build.sh
@@ -76,7 +76,7 @@ for i in $(ls arch/sbin); do
    echo "system-docker cp wonka.sh \${1}:/sbin/$i" >> /dist/arch/setup_wonka.sh
 done
 chmod 755 /dist/arch/setup_wonka.sh
-system-docker build --network=host -t iscsi-tools arch/
+system-docker build --build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY --network=host -t iscsi-tools arch/
 
 modprobe iscsi_tcp
 

--- a/images/20-iscsi/build.sh
+++ b/images/20-iscsi/build.sh
@@ -76,7 +76,20 @@ for i in $(ls arch/sbin); do
    echo "system-docker cp wonka.sh \${1}:/sbin/$i" >> /dist/arch/setup_wonka.sh
 done
 chmod 755 /dist/arch/setup_wonka.sh
-system-docker build --build-arg http_proxy=$HTTP_PROXY --build-arg https_proxy=$HTTPS_PROXY --network=host -t iscsi-tools arch/
+
+if [ "XX$HTTP_PROXY" != "XX" ]; then
+    BUILD_ARGS="--build-arg HTTP_PROXY --build-arg http_proxy="$HTTP_PROXY
+fi
+
+if [ "XX$HTTPS_PROXY" != "XX" ]; then
+    BUILD_ARGS=$BUILD_ARGS" --build-arg HTTPS_PROXY --build-arg https_proxy="$HTTPS_PROXY
+fi
+
+if [ "XX$NO_PROXY" != "XX" ]; then
+    BUILD_ARGS=$BUILD_ARGS" --build-arg NO_PROXY --build-arg no_proxy="$NO_PROXY
+fi
+
+system-docker build --network=host $BUILD_ARGS -t iscsi-tools arch/
 
 modprobe iscsi_tcp
 


### PR DESCRIPTION
Enabling the `open-iscsi` service on RancherOS didn't work due to this line, not giving to the build context the appropriates proxy variables.

It didn't work giving upper-case env var, this is why we have a lower-case as key and upper-case reference as value.
We can't let a lower-case reference as value because the [service definition](https://github.com/rancher/os-services/blob/ce870f9e95357e31f520ac2a21936edc16ebe75c/o/open-iscsi.yml#L11) takes only upper-case proxy variables.