### PR TITLE
Fix openvmtools build deps

### DIFF
--- a/images/10-openvmtools/Dockerfile
+++ b/images/10-openvmtools/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 	iproute2 \
 	sudo \
 	fuse \
-	libtirpc1 \
+	libtirpc-common \
 	libdumbnet1 \
 	libfuse2 \
 	libffi6 \


### PR DESCRIPTION
```
Package libtirpc1 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libtirpc-common

E: Package 'libtirpc1' has no installation candidate
```