### PR TITLE
Force aws-ecs-agent to use the host networking

### DIFF
--- a/a/amazon-ecs-agent.yml
+++ b/a/amazon-ecs-agent.yml
@@ -7,10 +7,10 @@ ecs-agent:
   - /opt/var/lib/ecs/data:/data
   - /sys/fs/cgroup:/sys/fs/cgroup:ro
   - /var/run/docker/execdriver/native:/var/lib/docker/execdriver/native:ro
-  ports:
-  - "127.0.0.1:51678:51678"
-  - "127.0.0.1:51679:51679"
+  net: host
   environment:
+  - ECS_ENABLE_TASK_IAM_ROLE=true
+  - ECS_ENABLE_TASK_IAM_ROLE_NETWORK_HOST=true
   - ECS_LOGFILE=/log/ecs-agent.log
   - ECS_LOGLEVEL=info
   - ECS_DATADIR=/data


### PR DESCRIPTION
According to Amazon's documentation in [step 10b Run the ECS container agent image](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-install.html), the ECS-Agent is only supported if running using the `host` networking instead of `bridge`. 

I also enabled Task IAM Role by default, to synchronize with the documentation update in rancher/docs#2015