### PR TITLE
images: pin amazon-metadata to alpine 3.11

### DIFF
--- a/images/20-amazonmetadata/Dockerfile
+++ b/images/20-amazonmetadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest
+FROM alpine:3.11
 # FROM arm64=skip arm=skip
 
 RUN apk -Uuv add bash jq ca-certificates groff less python py-pip && \


### PR DESCRIPTION
Fixes a broken build preventing a release to address an unrelated CVE.