### PR TITLE
Bumping version of zfs installer to 1.5.8

### DIFF
--- a/z/zfs.yml
+++ b/z/zfs.yml
@@ -1,5 +1,5 @@
 zfs:
-  image: ${REGISTRY_DOMAIN}/rancher/os-zfs:v0.7.13-1${SUFFIX}
+  image: ${REGISTRY_DOMAIN}/rancher/os-zfs:v1.5.8
   command: ./build.sh
   privileged: "true"
   labels:


### PR DESCRIPTION
Because zfs version 0.7.13 is very old now and for example does not support native encryption.

The only thing I can think of than can cause problems is that apparently there is no arm64 version available of that image

What do you think?